### PR TITLE
Optional ct

### DIFF
--- a/antsnetct/ants_helpers.py
+++ b/antsnetct/ants_helpers.py
@@ -244,7 +244,7 @@ def segment_and_bias_correct(anatomical_images, brain_mask, priors, work_dir, de
             List of paths to segmentation posteriors in order: CSF, GM, WM, deep GM, brainstem, cerebellum.
 
     """
-    if type(anatomical_images) == str:
+    if isinstance(anatomical_images, str):
         anatomical_images = [anatomical_images]
 
     if which_n4 is None:
@@ -627,7 +627,7 @@ def atropos_segmentation(anatomical_images, brain_mask, work_dir, iterations=15,
     """
     tmp_file_prefix = get_temp_file(work_dir, prefix='atropos')
 
-    if type(anatomical_images) == str:
+    if isinstance(anatomical_images, str):
         anatomical_images = [anatomical_images]
 
     atropos_cmd = ['Atropos', '-d', '3', '--verbose', '-x', brain_mask]
@@ -922,8 +922,7 @@ def apply_transforms(fixed_image, moving_image, transforms, work_dir, interpolat
     """
     tmp_file_prefix = get_temp_file(work_dir, prefix="aat")
 
-    moving_image_warped = f"{tmp_file_prefix}_{get_nifti_file_prefix(moving_image)}_to_" + \
-                                f"{get_nifti_file_prefix(fixed_image)}_warped.nii.gz"
+    moving_image_warped = f"{tmp_file_prefix}_warped.nii.gz"
 
     apply_cmd = [
         'antsApplyTransforms',
@@ -935,10 +934,12 @@ def apply_transforms(fixed_image, moving_image, transforms, work_dir, interpolat
         '--verbose', '1'
     ]
 
-    if type(transforms) == str:
+    if isinstance(transforms, str):
         apply_cmd.extend(['--transform', transforms])
     else:
         apply_cmd.extend([item for t in transforms for item in ('--transform', t)])
+
+
 
     run_command(apply_cmd)
 
@@ -1421,7 +1422,7 @@ def build_template(images, work_dir, initial_templates=None, reg_transform='SyN[
     num_modalities = 1
     num_images = len(images)
 
-    if type(images[0]) is list:
+    if isinstance(images[0], list):
         num_modalities = len(images)
         num_images = len(images[0])
         for mod_images in images:
@@ -1432,7 +1433,7 @@ def build_template(images, work_dir, initial_templates=None, reg_transform='SyN[
         images = [images]
 
     if initial_templates is not None:
-        if type(initial_templates) is not list:
+        if isinstance(initial_templates, str):
             initial_templates = [initial_templates]
 
         if len(initial_templates) != num_modalities:
@@ -1723,6 +1724,22 @@ def get_image_spacing(image):
     img = ants.image_read(image)
     return img.spacing
 
+def get_image_size(image):
+    """Get the size of an image
+
+    Parameters:
+    -----------
+    image : str
+        Path to image
+
+    Returns:
+    --------
+    list of int
+        Image size in voxels
+    """
+    img = ants.image_read(image)
+    return img.shape
+
 
 def resample_image_by_spacing(image, target_spacing, work_dir, interpolation='Linear'):
     """Resample an image to a new voxel spacing.
@@ -1769,3 +1786,41 @@ def resample_image_by_spacing(image, target_spacing, work_dir, interpolation='Li
     ants.image_write(resampled, resampled_file)
     return resampled_file
 
+
+def pad_image(image, pad_spec, work_dir, pad_to_shape=False):
+    """Pad an image with zeros
+
+    Parameters:
+    -----------
+    image : str
+        Path to image
+    pad_spec : list of int
+        Padding in voxels, e.g. [10, 10, 10] pads by 10 voxels on each side in x, y, z.
+
+        If pad_to_shape=True, the image will be padded until it reaches the specified size. If it is already larger, it will
+        not be altered.
+
+        If pad_to_shape=False, this can also be a list of list, e.g. [[0, 10], [10, 10], [5, 0]] to pad different amounts in
+        each dimension.
+    work_dir : str
+        Path to working directory
+
+    Returns:
+    --------
+    padded_image : str
+        Path to padded image
+    """
+    tmp_file_prefix = get_temp_file(work_dir, prefix='pad_image')
+
+    img = ants.image_read(image)
+
+    if pad_to_shape:
+        padded = ants.pad_image(img, shape=pad_spec)
+    else:
+        padded = ants.pad_image(img, pad_width=pad_spec)
+
+    padded_file = f"{tmp_file_prefix}_padded.nii.gz"
+
+    ants.image_write(padded, padded_file)
+
+    return padded_file

--- a/antsnetct/ants_helpers.py
+++ b/antsnetct/ants_helpers.py
@@ -8,6 +8,7 @@ import os
 
 from .system_helpers import run_command, get_nifti_file_prefix, copy_file, get_temp_file, get_temp_dir, get_verbose
 
+logger = logging.getLogger(__name__)
 
 def apply_mask(image, mask, work_dir):
     """Multiply an image by a mask
@@ -40,6 +41,9 @@ def apply_mask(image, mask, work_dir):
 
     ants.image_write(masked_img, masked_image_file)
 
+    if get_verbose():
+        logger.info(f"Masked image written to {masked_image_file}")
+
     return masked_image_file
 
 def smooth_image(image, sigma, work_dir):
@@ -66,6 +70,9 @@ def smooth_image(image, sigma, work_dir):
     smoothed_image_file = get_temp_file(work_dir, prefix='smooth_image') + '_smoothed.nii.gz'
 
     ants.image_write(smoothed_img, smoothed_image_file)
+
+    if get_verbose():
+        logger.info(f"Smoothed by {sigma} vox, output written to {smoothed_image_file}")
 
     return smoothed_image_file
 
@@ -119,6 +126,9 @@ def gamma_correction(image, gamma, work_dir):
     corrected_image_file = get_temp_file(work_dir, prefix='gamma_correction') + '_corrected.nii.gz'
 
     ants.image_write(corrected_img, corrected_image_file)
+
+    if get_verbose():
+        logger.info(f"Gamma corrected image written to {corrected_image_file}")
 
     return corrected_image_file
 
@@ -1705,6 +1715,10 @@ def combine_masks(masks, work_dir, thresh = 0.0001):
 
     ants.image_write(combined_mask, combined_mask_file)
 
+    if get_verbose():
+        logger.info(f"Combined {len(masks)} masks")
+        logger.info(f"Combined mask saved to {combined_mask_file}")
+
     return combined_mask_file
 
 
@@ -1784,6 +1798,11 @@ def resample_image_by_spacing(image, target_spacing, work_dir, interpolation='Li
     tmp_file_prefix = get_temp_file(work_dir, prefix='resample_by_spacing')
     resampled_file = f"{tmp_file_prefix}_resampled.nii.gz"
     ants.image_write(resampled, resampled_file)
+
+    if get_verbose():
+        logger.info(f"Image resampled to {target_spacing}")
+        logger.info(f"Resampled image saved to {resampled_file}")
+
     return resampled_file
 
 
@@ -1822,5 +1841,12 @@ def pad_image(image, pad_spec, work_dir, pad_to_shape=False):
     padded_file = f"{tmp_file_prefix}_padded.nii.gz"
 
     ants.image_write(padded, padded_file)
+
+    if get_verbose():
+        if pad_to_shape:
+            logger.info(f"Image padded to shape {padded.shape}")
+        else:
+            logger.info(f"Image padded by {pad_spec} voxels")
+        logger.info(f"Padded image saved to {padded_file}")
 
     return padded_file

--- a/antsnetct/cross_sectional_pipeline.py
+++ b/antsnetct/cross_sectional_pipeline.py
@@ -110,6 +110,9 @@ def cross_sectional_analysis():
 
     5. Atlas registration. If an atlas is defined, the T1w image is registered to the atlas.
 
+    If the '--longitudinal-preproc' option is used, steps 4 and 5 are skipped. This avoids having to compute thickness and
+    template registration twice for longitudinal data.
+
 
     --- Debugging / development / testing options ---
 
@@ -140,6 +143,8 @@ def cross_sectional_analysis():
     optional_parser = parser.add_argument_group("General optional arguments")
     optional_parser.add_argument("-h", "--help", action="help", help="show this help message and exit")
     optional_parser.add_argument("--bids-filter-file", help="BIDS filter file", type=str, default=None)
+    optional_parser.add_argument("--longitudinal-preproc", help="Skip thickness and template registration steps. Use this for "
+                                 "data that is only analyzed longitudinally", action='store_true')
     optional_parser.add_argument("--keep-workdir", help="Copy working directory to output, for debugging purposes. Either "
                                  "'never', 'on_error', or 'always'.", type=str, default='on_error')
     optional_parser.add_argument("--session", help="Session to process. Using this overrides any session filter in the BIDS "
@@ -347,6 +352,10 @@ def cross_sectional_analysis():
                                                   atropos_n4_iterations=args.atropos_n4_iterations,
                                                   atropos_prior_weight=args.atropos_prior_weight)
 
+                if args.longitudinal_preproc:
+                    logger.info("Skipping thickness and template registration steps")
+                    logger.info(f"Finished processing {t1w_bids.get_uri(relative=False)}")
+                    continue
                 logger.info("Computing cortical thickness")
                 thickness = cortical_thickness(seg_n4, working_dir, args.thickness_iterations)
 


### PR DESCRIPTION
Add an option to just preprocess for longitudinal processing, skip thickness and template registration entirely.

Also made some updates to SST definition. Different head positioning in group templates can lead to cropping of the head / face, mitigate this by ensuring that the FOV of the SST is at least as large as the original images. Might need more work and maybe users just have to use better templates. Or maybe replace group template initialization step with something better.